### PR TITLE
Important: Duplicate dependecies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,5 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
leads to problems with installing ng2-dnd 1.6.0