### PR TITLE
cloneItem on sortables

### DIFF
--- a/bundles/ng2-dnd.js
+++ b/bundles/ng2-dnd.js
@@ -438,6 +438,8 @@ System.registerDynamic("src/dnd.sortable", ["@angular/core", "./dnd.component", 
     __decorate([core_2.Input(), __metadata('design:type', Object)], SortableComponent.prototype, "dragData", void 0);
     __decorate([core_2.Input("effectAllowed"), __metadata('design:type', String), __metadata('design:paramtypes', [String])], SortableComponent.prototype, "effectallowed", null);
     __decorate([core_2.Input("effectCursor"), __metadata('design:type', String), __metadata('design:paramtypes', [String])], SortableComponent.prototype, "effectcursor", null);
+    __decorate([core_2.Input(), __metadata('design:type', Object)], SortableComponent.prototype, "dragImage", void 0);
+    __decorate([core_2.Input(), __metadata('design:type', Boolean)], SortableComponent.prototype, "cloneItem", void 0);
     __decorate([core_2.Output("onDragSuccess"), __metadata('design:type', core_2.EventEmitter)], SortableComponent.prototype, "onDragSuccessCallback", void 0);
     __decorate([core_2.Output("onDragStart"), __metadata('design:type', core_2.EventEmitter)], SortableComponent.prototype, "onDragStartCallback", void 0);
     __decorate([core_2.Output("onDragOver"), __metadata('design:type', core_2.EventEmitter)], SortableComponent.prototype, "onDragOverCallback", void 0);

--- a/bundles/ng2-dnd.js
+++ b/bundles/ng2-dnd.js
@@ -705,7 +705,7 @@ System.registerDynamic("src/dnd.component", ["@angular/core", "./dnd.config", ".
         }
       };
       this._elem.ondragend = function(event) {
-        _this._elem.parentElement.removeChild(_this._dragHelper);
+        _this._dragHelper.parentElement.removeChild(_this._dragHelper);
         _this._onDragEnd(event);
         _this._elem.style.cursor = _this._defaultCursor;
       };

--- a/src/dnd.component.ts
+++ b/src/dnd.component.ts
@@ -152,7 +152,7 @@ export abstract class AbstractComponent {
             }
         };
         this._elem.ondragend = (event: Event) => {
-            this._elem.parentElement.removeChild(this._dragHelper);
+            this._dragHelper.parentElement.removeChild(this._dragHelper);
             // console.log('ondragend', event.target);
             this._onDragEnd(event);
             // Restore style of dragged element

--- a/src/dnd.sortable.ts
+++ b/src/dnd.sortable.ts
@@ -93,6 +93,10 @@ export class SortableComponent extends AbstractComponent {
         this.effectCursor = value;
     }
 
+    @Input() dragImage: string | DragImage | Function;
+
+    @Input() cloneItem: boolean;
+
     /**
      * Callback function called when the drag action ends with a valid drop action.
      * It is activated after the on-drop-success callback


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Allows using cloneItem on sortables. If sortables are moved to different container, the dragHelper element needs to be removed in a different way, since they are no longer in inside the elements parentElement.
- **What is the current behavior?** (You can also link to an open issue here)

SortableComponent doesn't take cloneItem as an Input.
- **What is the new behavior (if this is a feature change)?**

You can use cloneItem on SortableComponent and move them between lists.
- **Other information**:

The dragHelper has left: -1000px, for me this didn't work, but since it had a class I overwrote it with CSS: `left: 0px; z-index: -1`.

I didn't change it here because I'm not clear on _what the cause was_. Using a dragImage with a DOM element is quite tricky, more here if anyone is interested: http://www.kryogenix.org/code/browser/custom-drag-image.html
