### PR TITLE
chore(build): use ngc for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,15 @@ typings
 bundles
 src/*.js
 src/*.d.ts
+src/*.metadata.json
 src/*.js.map
 tests/*.js
 tests/*.d.ts
+tests/*.metadata.json
 tests/*.js.map
 index.js
 index.d.ts
+index.metadata.json
 index.js.map
 _test-output
 

--- a/.npmignore
+++ b/.npmignore
@@ -13,7 +13,9 @@ typings.json
 **/*.ts
 **/*.js.map
 !*.d.ts
+!*.metadata.json
 !src/*.d.ts
+!src/*.metadata.json
 !tests/*.d.ts
 .travis.yml
 karma*

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "tsc && karma start",
     "test-watch": "tsc && karma start --no-single-run --auto-watch",
     "minify": "node node_modules/uglify-js/bin/uglifyjs bundles/ng2-dnd.js -o bundles/ng2-dnd.min.js --source-map bundles/ng2-dnd.min.js.map -c -m",
-    "prepublish": "typings install && tsc && node make.js && npm run minify",
+    "prepublish": "typings install && ngc && node make.js && npm run minify",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -36,11 +36,14 @@
     "zone.js": "^0.6.23"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
-    "@angular/platform-browser": "2.0.0",
-    "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/common": "~2.2.0",
+    "@angular/compiler": "~2.2.0",
+    "@angular/compiler-cli": "~2.2.0",
+    "@angular/core": "~2.2.0",
+    "@angular/platform-browser": "~2.2.0",
+    "@angular/platform-browser-dynamic": "~2.2.0",
+    "@types/jasmine": "^2.5.38",
+    "@types/node": "0.0.2",
     "commitizen": "^2.7.6",
     "cz-conventional-changelog": "^1.1.5",
     "jasmine-core": "~2.5.1",

--- a/src/dnd.config.ts
+++ b/src/dnd.config.ts
@@ -2,10 +2,8 @@
 // This project is licensed under the terms of the MIT license.
 // https://github.com/akserg/ng2-dnd
 
-import {Injectable} from '@angular/core';
 import {isString} from './dnd.utils';
 
-@Injectable()
 export class DataTransferEffect {
 
     static COPY = new DataTransferEffect('copy');
@@ -16,7 +14,6 @@ export class DataTransferEffect {
     constructor(public name: string) { }
 }
 
-@Injectable()
 export class DragImage {
     constructor(
         public imageElement: string | HTMLElement,
@@ -31,7 +28,6 @@ export class DragImage {
         }
 }
 
-@Injectable()
 export class DragDropConfig {
     public onDragStartClass: string = "dnd-drag-start";
     public onDragEnterClass: string = "dnd-drag-enter";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,14 @@
         "experimentalDecorators": true,
         "declaration": true,
         "moduleResolution": "node",
-        "sourceMap": true
+        "sourceMap": true,
+        "lib": [
+          "dom",
+          "es2015"
+        ]
+    },
+    "angularCompilerOptions": {
+      "skipTemplateCodegen": true,
+      "strictMetadataEmit": true
     }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,0 @@
-{
-  "globalDependencies": {
-    "core-js": "registry:dt/core-js#0.0.0+20160725163759",
-    "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
-    "node": "registry:dt/node#6.0.0+20160909174046"
-  }
-}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Build tooling change

* **What is the current behavior?** (You can also link to an open issue here)

Library uses tsc to compile before deployment, and does not generate the necessary metadata to allow consumers to ahead-of-time (AoT) compile their apps if they are using ng2-dnd

* **What is the new behavior (if this is a feature change)?**

For npm prepublish, use `ngc` (@angular/compiler-cli) to generate the metadata.json files - they contain the information in decorators that is lost during transpilation. This allows users to AoT compile their apps. 


* **Other information**:

Removed `@Injectable()` decorators from non-Injected classes, as this is unnecessary, and breaks AoT compilation, as angular tries to resolve `string` `HTMLElement` etc as injectable providers.

closes #84 