### PR TITLE
Changes to demo 5 so it works with Angular 2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ import {Component} from '@angular/core';
             <div class="panel-heading">Place to drop (Items:{{receivedData.length}})</div>
             <div class="panel-body">
                 <div [hidden]="!receivedData.length > 0"
-                    *ngFor="#data of receivedData">{{data | json}}</div>
+                    *ngFor="let data of receivedData">{{data | json}}</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
5. Transfer custom data via Drag-and-Drop
Copying the template as is does not work in Angular 2.2.3, so this small change makes the template work.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


* **What is the current behavior?** (You can also link to an open issue here)
Example breaks in Angular 2.2.3


* **What is the new behavior (if this is a feature change)?**
Example works.


* **Other information**:
