### PR TITLE
Remove confusing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ System.config({
 });
 ```
 
-#### 1. Update the markup
+#### 1. Add the default styles
 - Import the `style.css` into your web page
-- Add `<ng2-dnd></ng2-dnd>` tag in template of your application component.
 
 #### 2. Import the `DndModule`
 Import `DndModule.forRoot()` in the NgModule of your application. 


### PR DESCRIPTION
Why add the tag? It's not needed at all for the plugin to work. Having this in the instructions just causes the project to crash - see https://github.com/akserg/ng2-dnd/issues/94
