### PR TITLE
Fix Drag Lifecycle events not fired for data transfers

### DIFF
--- a/src/droppable.component.ts
+++ b/src/droppable.component.ts
@@ -56,21 +56,22 @@ export class DroppableComponent extends AbstractComponent {
     }
 
     _onDragEnterCallback(event: MouseEvent) {
-        if (this._dragDropService.isDragged) {
+        if (this._dragDropService.isDragged || this._isDataTransfer(event)) {
             this._elem.classList.add(this._config.onDragEnterClass);
             this.onDragEnter.emit({dragData: this._dragDropService.dragData, mouseEvent: event});
         }
     }
 
     _onDragOverCallback (event: MouseEvent) {
-        if (this._dragDropService.isDragged) {
+      let dataTransfer = (event as any).dataTransfer;
+        if (this._dragDropService.isDragged || this._isDataTransfer(event)) {
             this._elem.classList.add(this._config.onDragOverClass);
             this.onDragOver.emit({dragData: this._dragDropService.dragData, mouseEvent: event});
         }
     };
 
     _onDragLeaveCallback (event: MouseEvent) {
-        if (this._dragDropService.isDragged) {
+        if (this._dragDropService.isDragged || this._isDataTransfer(event)) {
             this._elem.classList.remove(this._config.onDragOverClass);
             this._elem.classList.remove(this._config.onDragEnterClass);
             this.onDragLeave.emit({dragData: this._dragDropService.dragData, mouseEvent: event});
@@ -78,8 +79,7 @@ export class DroppableComponent extends AbstractComponent {
     };
 
     _onDropCallback (event: MouseEvent) {
-        let dataTransfer = (event as any).dataTransfer;
-        if (this._dragDropService.isDragged || (dataTransfer && dataTransfer.files)) {
+        if (this._dragDropService.isDragged || this._isDataTransfer(event)) {
             this.onDropSuccess.emit({dragData: this._dragDropService.dragData, mouseEvent: event});
             if (this._dragDropService.onDragSuccessCallback) {
                 this._dragDropService.onDragSuccessCallback.emit({dragData: this._dragDropService.dragData, mouseEvent: event});
@@ -87,5 +87,10 @@ export class DroppableComponent extends AbstractComponent {
             this._elem.classList.remove(this._config.onDragOverClass);
             this._elem.classList.remove(this._config.onDragEnterClass);
         }
+    }
+
+    private _isDataTransfer(event: any) {
+      const dataTransfer = event.dataTransfer;
+      return dataTransfer && dataTransfer.files;
     }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/akserg/ng2-dnd/issues/175

* **What is the new behavior (if this is a feature change)?**

"Lifecycle" events are now correctly emitted when a file is dragged over a `dnd-droppable`-Enabled element.

* **Other information**:
