### PR TITLE
dnd-sortable-handle DragDropService leak fixed

### DIFF
--- a/src/abstract.component.ts
+++ b/src/abstract.component.ts
@@ -2,7 +2,7 @@
 // This project is licensed under the terms of the MIT license.
 // https://github.com/akserg/ng2-dnd
 
-import {Injectable, ChangeDetectorRef, ViewRef} from '@angular/core';
+import {Injectable, ChangeDetectorRef, ViewRef, OnDestroy} from '@angular/core';
 import {ElementRef} from '@angular/core';
 
 import { DragDropConfig, DragImage } from './dnd.config';
@@ -12,7 +12,7 @@ import { isString, isFunction, isPresent, createImage, callFun } from './dnd.uti
 @Injectable()
 export abstract class AbstractComponent {
     _elem: HTMLElement;
-    _dragHandle: HTMLElement;
+    _dragHandle: HTMLElement | undefined;
     _dragHelper: HTMLElement;
     _defaultCursor: string;
 
@@ -185,7 +185,7 @@ export abstract class AbstractComponent {
         };
     }
 
-    public setDragHandle(elem: HTMLElement) {
+    public setDragHandle(elem: HTMLElement | undefined) {
         this._dragHandle = elem;
     }
     /******* Change detection ******/
@@ -300,11 +300,15 @@ export abstract class AbstractComponent {
     _onDragEndCallback(event: Event) { }
 }
 
-export class AbstractHandleComponent {
+export class AbstractHandleComponent implements OnDestroy {
     _elem: HTMLElement;
     constructor(elemRef: ElementRef, public _dragDropService: DragDropService, public _config: DragDropConfig,
         private _Component: AbstractComponent, private _cdr: ChangeDetectorRef) {
         this._elem = elemRef.nativeElement;
         this._Component.setDragHandle(this._elem);
+    }
+
+    ngOnDestroy() {
+        this._Component.setDragHandle(undefined);
     }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Elements that had a `dnd-sortable-handle` attributes get referenced by `DragDropService` event even when the associated element is destroyed.


* **What is the new behavior (if this is a feature change)?**
This pull request adds a `ngOnDestroy` handler to `AbstractHandleComponent` that removes the element from the `DragDropService` before it gets destroyed. So it can be garbage collected by the browser.


* **Other information**:

