### PR TITLE
Fixed dragData of nested draggable element.

### DIFF
--- a/src/abstract.component.ts
+++ b/src/abstract.component.ts
@@ -280,6 +280,7 @@ export abstract class AbstractComponent {
             this._dragDropService.allowedDropZones = this.dropZones;
             // console.log('ondragstart.allowedDropZones', this._dragDropService.allowedDropZones);
             this._onDragStartCallback(event);
+            event.stopPropagation();
         }
     }
 

--- a/src/abstract.component.ts
+++ b/src/abstract.component.ts
@@ -280,7 +280,9 @@ export abstract class AbstractComponent {
             this._dragDropService.allowedDropZones = this.dropZones;
             // console.log('ondragstart.allowedDropZones', this._dragDropService.allowedDropZones);
             this._onDragStartCallback(event);
-            event.stopPropagation();
+            if (event.stopPropagation) {
+                event.stopPropagation();
+            }
         }
     }
 


### PR DESCRIPTION
First of all I appreciate for your work.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When using recursive custom component cannot get "dragData" of nested element but parent's.

* **What is the new behavior (if this is a feature change)?**
Can get "dragData" of nested element.


* **Other information**:
example of recursive custom component.
"app-some-list", "app-some" is custom component.
```html
<app-some-list [inputList]="items">
    <app-some id="parent" *ngFor="let item of items" dnd-draggable [dragEnabled]="true" [dragData]="item">
        <app-some-list [inputList]="item.childItems">
            <app-some id="child"></app-some>
            ...
        </app-some-list>
    </app-some>
</app-some-list>
```

Always return parent's dragData even if I drag a child.
Thanks.

