### PR TITLE
allows for nested dragging with handles sans disabling

### DIFF
--- a/src/abstract.component.ts
+++ b/src/abstract.component.ts
@@ -27,7 +27,12 @@ export abstract class AbstractComponent {
     private _dragEnabled: boolean = false;
     set dragEnabled(enabled: boolean) {
         this._dragEnabled = !!enabled;
-        this._elem.draggable = this._dragEnabled;
+        let cursorelem = this._elem;
+        if(this._dragHandle) {
+            cursorelem = this._dragHandle;
+            this._elem.draggable = undefined;
+        }
+        cursorelem.draggable = this._dragEnabled;
     }
     get dragEnabled(): boolean {
         return this._dragEnabled;
@@ -119,13 +124,22 @@ export abstract class AbstractComponent {
         this._elem.ondrop = (event: Event) => {
             this._onDrop(event);
         };
+        setTimeout(() => {
+            if(!this._elem.querySelector('[dnd-sortable-handle]')) {
+                this.bindDragging(this._elem);
+            }
+        })
+
+    }
+
+    bindDragging(elem: HTMLElement) {
         //
         // Drag events
         //
-        this._elem.onmousedown = (event: MouseEvent) => {
+        elem.onmousedown = (event: MouseEvent) => {
             this._target = event.target;
         };
-        this._elem.ondragstart = (event: DragEvent) => {
+        elem.ondragstart = (event: DragEvent) => {
             if (this._dragHandle) {
                 if (!this._dragHandle.contains(<Element>this._target)) {
                     event.preventDefault();
@@ -173,7 +187,7 @@ export abstract class AbstractComponent {
             }
         };
 
-        this._elem.ondragend = (event: Event) => {
+        elem.ondragend = (event: Event) => {
             if (this._elem.parentElement && this._dragHelper) {
                 this._elem.parentElement.removeChild(this._dragHelper);
             }
@@ -187,6 +201,8 @@ export abstract class AbstractComponent {
 
     public setDragHandle(elem: HTMLElement) {
         this._dragHandle = elem;
+        this.bindDragging(elem);
+        this.dragEnabled = this._dragEnabled;
     }
     /******* Change detection ******/
 


### PR DESCRIPTION
allows for nested dragging with handles without the need for disabling parent or child

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix for nested handles
- Feature for nested dragging without the need for disabling

* **What is the current behavior?** (You can also link to an open issue here)
- Handles have not been working in a drop zone at all
- Nested draggables require disabling the parent to drag the child
#193 #58 #20 #56 

* **What is the new behavior (if this is a feature change)?**
- Allows for handles within a drop zone
- Nested draggables do not require disabling the parent if the parent has a handle

* **Other information**:
