### PR TITLE
fix #80 and #171 :  added a setTimeout in dragStart event for chrome

### DIFF
--- a/src/draggable.component.ts
+++ b/src/draggable.component.ts
@@ -91,7 +91,11 @@ export class DraggableComponent extends AbstractComponent {
         this._dragDropService.isDragged = true;
         this._dragDropService.dragData = this.dragData;
         this._dragDropService.onDragSuccessCallback = this.onDragSuccessCallback;
-        this._elem.classList.add(this._config.onDragStartClass);
+        setTimeout(() => {
+            // The DOM changes when adding the CSS class, so we need to add the setTimeout for Chrome
+            // see https://stackoverflow.com/questions/19639969/html5-dragend-event-firing-immediately
+            this._elem.classList.add(this._config.onDragStartClass);
+        });
         //
         this.onDragStart.emit({dragData: this.dragData, mouseEvent: event});
     }

--- a/src/sortable.component.ts
+++ b/src/sortable.component.ts
@@ -179,7 +179,11 @@ export class SortableComponent extends AbstractComponent {
         this._sortableDataService.isDragged = true;
         this._sortableDataService.sortableContainer = this._sortableContainer;
         this._sortableDataService.index = this.index;
-        this._sortableDataService.markSortable(this._elem);
+        setTimeout(() => {
+            // The DOM changes when adding the CSS class, so we need to add the setTimeout for Chrome
+            // see https://stackoverflow.com/questions/19639969/html5-dragend-event-firing-immediately
+            this._sortableDataService.markSortable(this._elem);
+        });
         // Add dragData
         this._dragDropService.isDragged = true;
         this._dragDropService.dragData = this.dragData;

--- a/tests/dnd.with.draggable.data.spec.ts
+++ b/tests/dnd.with.draggable.data.spec.ts
@@ -69,13 +69,15 @@ describe('Drag and Drop with draggable data', () => {
 
         triggerEvent(dragElem, 'dragstart', 'MouseEvent');
         componentFixture.detectChanges();
-        expect(dragElem.classList.contains(config.onDragStartClass)).toEqual(true);
+        setTimeout(function() {
+            expect(dragElem.classList.contains(config.onDragStartClass)).toEqual(true);
 
-        triggerEvent(dragElem, 'dragend', 'MouseEvent');
-        componentFixture.detectChanges();
-        expect(dragElem.classList.contains(config.onDragStartClass)).toEqual(false);
+            triggerEvent(dragElem, 'dragend', 'MouseEvent');
+            componentFixture.detectChanges();
+            expect(dragElem.classList.contains(config.onDragStartClass)).toEqual(false);
 
-        done();
+            done();
+        }, 1);
     });
 
     it('Drag start event should not be activated if drag is not enabled', (done:any) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix bugs #80 and #171 

* **Other information**:
I added a setTimeout for Chrome on the dragStart event when modifying the CSS class, following advice found here : https://stackoverflow.com/questions/19639969/html5-dragend-event-firing-immediately
