### PR TITLE
Add event emitter for when input list is modified

### DIFF
--- a/src/sortable.component.ts
+++ b/src/sortable.component.ts
@@ -163,6 +163,9 @@ export class SortableComponent extends AbstractComponent {
     @Output("onDragOver") onDragOverCallback: EventEmitter<any> = new EventEmitter<any>();
     @Output("onDragEnd") onDragEndCallback: EventEmitter<any> = new EventEmitter<any>();
     @Output("onDropSuccess") onDropSuccessCallback: EventEmitter<any> = new EventEmitter<any>();
+    
+    // Emits when sortable data is modified.
+    @Output("onListReorder") onListReorderCallback = new EventEmitter<void>();
 
     constructor(elemRef: ElementRef, dragDropService: DragDropService, config:DragDropConfig,
         private _sortableContainer: SortableContainer,
@@ -233,6 +236,7 @@ export class SortableComponent extends AbstractComponent {
                 this._sortableDataService.sortableContainer = this._sortableContainer;
                 this._sortableDataService.index = this.index;
                 this.detectChanges();
+                this.onListReorderCallback.emit();
             }
         }
     }


### PR DESCRIPTION
* This allows OnPush components to use the sortable component.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
No event is emitted so the wrapping components can't be OnPush.


* **What is the new behavior (if this is a feature change)?**
Emits an event when the sortable data is reordered. Components can listen for the event and call for change detection if needed.


* **Other information**:
