### PR TITLE
Keep already set dataTransfer "text" data

### DIFF
--- a/src/abstract.component.ts
+++ b/src/abstract.component.ts
@@ -136,7 +136,11 @@ export abstract class AbstractComponent {
             this._onDragStart(event);
             //
             if (event.dataTransfer != null) {
-                event.dataTransfer.setData('text', '');
+
+                if (!event.dataTransfer.getData('text')) {
+                    event.dataTransfer.setData('text', '');
+                }
+
                 // Change drag effect
                 event.dataTransfer.effectAllowed = this.effectAllowed || this._config.dragEffect.name;
                 // Change drag image


### PR DESCRIPTION
It fixes a problem where the drag resets the "text" data on dataTransfer which lead to problems when dragging to an external application. 

Now the dataTransfer is only set to '' when nothing else is set yet.
