### PR TITLE
Adding support for dragImage

### DIFF
--- a/src/abstract.component.ts
+++ b/src/abstract.component.ts
@@ -142,9 +142,9 @@ export abstract class AbstractComponent {
                 // Change drag image
                 if (isPresent(this.dragImage)) {
                     if (isString(this.dragImage)) {
-                        (<any>event.dataTransfer).setDragImage(createImage(<string>this.dragImage));
+                        (<any>event.dataTransfer).setDragImage(createImage(<string>this.dragImage, 0, 0));
                     } else if (isFunction(this.dragImage)) {
-                        (<any>event.dataTransfer).setDragImage(callFun(<Function>this.dragImage));
+                        (<any>event.dataTransfer).setDragImage(callFun(<Function>this.dragImage, 0, 0));
                     } else {
                         let img: DragImage = <DragImage>this.dragImage;
                         (<any>event.dataTransfer).setDragImage(img.imageElement, img.x_offset, img.y_offset);

--- a/src/dnd.utils.ts
+++ b/src/dnd.utils.ts
@@ -27,7 +27,7 @@ export function isFunction(obj: any) {
  * Create Image element with specified url string
  */
 export function createImage(src: string) {
-    let img:HTMLImageElement = new HTMLImageElement();
+    let img:HTMLImageElement = document.createElement('img');
     img.src = src;
     return img;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds support for `dragImage` as reported in https://github.com/akserg/ng2-dnd/issues/63


* **What is the current behavior?** (You can also link to an open issue here)
It's not possible to set a custom drag image like it's described in any of the three possibilities here: https://github.com/akserg/ng2-dnd/blob/master/src/draggable.component.ts#L54-L76

* **What is the new behavior (if this is a feature change)?**
Allows to set a custom drag image

* **Other information**:
